### PR TITLE
Fixed bug where Spring's BeanRowMapper blows up if a primitive typein…

### DIFF
--- a/api/src/main/java/org/collegeopentextbooks/api/model/Author.java
+++ b/api/src/main/java/org/collegeopentextbooks/api/model/Author.java
@@ -6,7 +6,7 @@ package org.collegeopentextbooks.api.model;
  *
  */
 public class Author extends AbstractModelObject {
-	private int repositoryId;
+	private Integer repositoryId;
 	private String name;
 	private String searchName;
 	
@@ -14,10 +14,10 @@ public class Author extends AbstractModelObject {
 	public Author(String name) {
 		this.setName(name);
 	}
-	public int getRepositoryId() {
+	public Integer getRepositoryId() {
 		return repositoryId;
 	}
-	public void setRepositoryId(int repositoryId) {
+	public void setRepositoryId(Integer repositoryId) {
 		this.repositoryId = repositoryId;
 	}
 	public String getName() {

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-application.version=0.1.20180401
+application.version=0.1.20180414
 
 spring.datasource.url=jdbc:postgresql://localhost:5432/cot
 spring.datasource.username=api


### PR DESCRIPTION
… the mapped object is null in the database